### PR TITLE
zsh設定改善: 遅延読み込みと起動高速化

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,51 @@ ln -s $HOME/dotfiles/zsh/.zshrc $HOME/.config/zsh/.zshrc
 ln -s $HOME/dotfiles/zsh/config $HOME/.config/zsh/config
 ```
 
-### Usage
+### 必要なツール
 
-整備中
+#### 必須
+
+```bash
+# Arch Linux / EndeavourOS
+pacman -S zsh eza zoxide fzf bat fd ripgrep neovim btop git
+```
+
+| ツール | 説明 | エイリアス |
+| ------ | ---- | ---------- |
+| [eza](https://github.com/eza-community/eza) | モダンなls | `ls`, `la`, `ll`, `lt` |
+| [zoxide](https://github.com/ajeetdsouza/zoxide) | スマートcd | `cd`/`z`, `cdi`/`zi` |
+| [fzf](https://github.com/junegunn/fzf) | ファジーファインダー | `fcd`, `fv`, `fgs`, `flog` |
+| [bat](https://github.com/sharkdp/bat) | catの代替 | fzfプレビュー |
+| [fd](https://github.com/sharkdp/fd) | findの代替 | fzf検索 |
+| [ripgrep](https://github.com/BurntSushi/ripgrep) | grepの代替 | fzf検索 |
+| [neovim](https://neovim.io/) | エディタ | `v`, `vim` |
+| [btop](https://github.com/aristocratos/btop) | システムモニター | `top` |
+
+#### オプション（使用時に遅延読み込み）
+
+```bash
+# 必要に応じてインストール
+pacman -S kubectl helm terraform
+yay -S aws-cli-v2
+```
+
+| ツール | 説明 |
+| ------ | ---- |
+| [kubectl](https://kubernetes.io/docs/reference/kubectl/) | Kubernetes CLI |
+| [helm](https://helm.sh/) | Kubernetes パッケージマネージャー |
+| [terraform](https://www.terraform.io/) | IaC ツール |
+| [aws-cli](https://aws.amazon.com/cli/) | AWS CLI |
+| [go](https://go.dev/) | Go言語 |
+| [docker](https://www.docker.com/) | コンテナ |
+
+### 主なエイリアス
+
+| カテゴリ | エイリアス |
+| -------- | ---------- |
+| Git | `g`, `ga`, `gc`, `gd`, `gs`, `gsw`, `gl`, `gp`, `gpl` |
+| Docker | `d`, `dc`, `dcu`, `dcd`, `dps` |
+| Kubernetes | `k`, `kgp`, `kgs`, `kgd`, `kga`, `kl` |
+| fzf | `fcd`(cd), `fv`(vim), `fgs`(git switch), `flog`(git log) |
 
 ## Neovim
 

--- a/i3/config
+++ b/i3/config
@@ -167,7 +167,7 @@ exec --no-startup-id xrandr --output DP-0 --mode 3840x2160 --rate 144
 
 # 壁紙設定
 # 何故か設定が効かないので保留。一旦zshで設定する
-exec --no-startup-id feh --bg-fill /usr/share/endeavouros/backgrounds/girl.png
+exec --no-startup-id feh --bg-fill /usr/share/endeavouros/backgrounds/girl.jpeg
 
 # ディスプレイの電源管理
 exec --no-startup-id xset s off dpms 1800 1800 1800  # 30分後にオフ

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -51,19 +51,12 @@ export SSH_CONFIG=$HOME/.ssh/config
 export GNUPGHOME=$HOME/.gnupg
 
 # ==================================================
-# 開発ツールのパス設定
-# ==================================================
-# Go言語の実行可能ファイルのディレクトリをPATHに追加
-export PATH=$PATH:$GOPATH/bin
-## Node.jsのグローバルパッケージの場所を指定
-#export NODE_PATH=$HOME/.node_modules_global/lib/node_modules
-## Pythonの仮想環境のデフォルト保存場所を設定
-#export WORKON_HOME=$HOME/.virtualenvs
-
-# ==================================================
 # Go言語開発環境の設定
 # ==================================================
-# Go言語のワークスペースパスを設定
-export GOPATH=$(go env GOPATH)
-# Goのプロジェクトファイルのルートディレクトリを設定
-export GHQ_ROOT=$GOPATH/pkg/mod
+# Go言語のワークスペースパスを設定（goコマンドが存在する場合のみ）
+if command -v go &>/dev/null; then
+    export GOPATH=$(go env GOPATH)
+    export PATH=$PATH:$GOPATH/bin
+    # Goのプロジェクトファイルのルートディレクトリを設定
+    export GHQ_ROOT=$GOPATH/pkg/mod
+fi

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -5,28 +5,16 @@ ZSH_DIR="${XDG_CONFIG_HOME}/zsh"
 autoload -Uz compinit
 compinit
 
-# aws cli の補完
-autoload bashcompinit
+# bashcompinit (aws等のbash補完を使うため)
+autoload -Uz bashcompinit
 bashcompinit
-complete -C '/usr/local/bin/aws_completer' aws
 
-# Go 補完
-# go install github.com/posener/complete/v2/gocomplete@latest
-# COMP_INSTALL=1 $HOME/go/bin/gocomplete
-complete -C $HOME/go/bin/gocomplete go
-
-# zshがディレクトリで、読み取り、実行が可能なとき
-if [ -d "$ZSH_DIR" ] && [ -r "$ZSH_DIR" ] && [ -x "$ZSH_DIR" ]; then
-    for file in ${ZSH_DIR}/*/*.zsh; do
-        # 読み取り可能ならば実行する
-        if [ -r "$file" ]; then
-            source "$file"
-        else
-            echo "Error: Cannot read $file"
-        fi
+# config/*.zsh を読み込む
+if [[ -d "$ZSH_DIR" && -r "$ZSH_DIR" && -x "$ZSH_DIR" ]]; then
+    for file in ${ZSH_DIR}/config/*.zsh; do
+        [[ -r "$file" ]] && source "$file"
     done
-else
-    echo "Error: ${ZSH_DIR} is not accessible."
 fi
 
-. "$HOME/.local/share//../bin/env"
+# uv (Python package manager)
+[[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"

--- a/zsh/config/aliases.zsh
+++ b/zsh/config/aliases.zsh
@@ -1,24 +1,78 @@
-# ls -> exa
-alias ls='exa --color=auto'
-alias la='exa -la'
-alias ll='exa -l'
-
-# top -> bpytop
-alias top='bpytop'
-
-# nvim
-alias v='nvim'
-alias vim='nvim'
-
-# clear
-alias c='clear'
-alias cc='c &&'
+###################### ファイル操作 ######################
+# ls -> eza (exa's maintained fork)
+alias ls='eza --color=auto --icons --sort=Name'
+alias la='eza -la --icons --sort=Name'
+alias ll='eza -l --icons --sort=Name'
+alias lt='eza --tree --level=2 --icons --sort=Name'
 
 # 実行前確認
 alias rm='rm -i'
 alias mv='mv -i'
 alias cp='cp -i'
 
-# Network
-alias ports='netstat -tulanp'          # 開いているポートと使用中のプロセスを表示
-alias myip='curl http://ipinfo.io/ip'  # 自分のグローバルIP
+# mkdir with parents
+alias mkdir='mkdir -pv'
+
+###################### エディタ ######################
+alias v='nvim'
+alias vim='nvim'
+
+###################### システム ######################
+# top -> btop
+alias top='btop'
+
+# clear
+alias c='clear'
+
+# disk usage
+alias df='df -h'
+alias du='du -h'
+alias dud='du -d 1'
+
+# grep
+alias grep='grep --color=auto'
+
+###################### ネットワーク ######################
+alias ports='ss -tulanp'               # 開いているポートと使用中のプロセスを表示
+alias myip='curl -s http://ipinfo.io/ip'  # 自分のグローバルIP
+alias localip="ip -4 addr show | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v 127.0.0.1"
+
+###################### Git ######################
+alias g='git'
+alias ga='git add'
+alias gaa='git add -A'
+alias gc='git commit'
+alias gcm='git commit -m'
+alias gco='git checkout'
+alias gd='git diff'
+alias gds='git diff --staged'
+alias gl='git log --oneline --graph'
+alias gp='git push'
+alias gpl='git pull'
+alias gs='git status'
+alias gsw='git switch'
+
+###################### Docker ######################
+alias d='docker'
+alias dc='docker compose'
+alias dcu='docker compose up -d'
+alias dcd='docker compose down'
+alias dps='docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'
+alias dpsa='docker ps -a --format "table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'
+
+###################### Kubernetes ######################
+alias k='kubectl'
+alias kgp='kubectl get pods'
+alias kgs='kubectl get services'
+alias kgd='kubectl get deployments'
+alias kga='kubectl get all'
+alias kd='kubectl describe'
+alias kl='kubectl logs'
+alias klf='kubectl logs -f'
+
+###################### zoxide (smarter cd) ######################
+if command -v zoxide &>/dev/null; then
+    eval "$(zoxide init zsh)"
+    alias cd='z'      # cdをzに置き換え
+    alias cdi='zi'    # インタラクティブモード
+fi

--- a/zsh/config/arch.zsh
+++ b/zsh/config/arch.zsh
@@ -5,14 +5,4 @@
 alias pacmanupdate='pacman -Syu ; paccache -ruk3'
 alias yayupdate='yay -Syu && paccache -r && paccache -ruk3'
 
-# 背景設定
-background="/usr/share/endeavouros/backgrounds/girl.jpeg"
-/usr/bin/feh --no-fehbg --bg-fill $background
-
-if ! /usr/bin/pgrep -x "picom" > /dev/null
-then
-    /usr/bin/picom -b
-fi
-
-# kubectl completion
-source <(kubectl completion zsh)
+# Note: feh/picom are started by i3 config, not here

--- a/zsh/config/base.zsh
+++ b/zsh/config/base.zsh
@@ -11,6 +11,7 @@ setopt extended_history         # コマンドのタイムスタンプをHISTFIL
 setopt hist_expire_dups_first   # HISTFILEのサイズがHISTSIZEを超える場合、最初に重複を削除
 
 ###################### 補完設定 ######################
+zstyle ':completion:*' matcher-list '' 'm:{a-zA-Z}={A-Za-z}'  # 大文字小文字を区別しない補完
 setopt auto_param_slash          # ディレクトリ名の補完で末尾に / を自動追加
 setopt auto_param_keys           # ()を自動補完
 setopt mark_dirs                 # ディレクトリにマッチした場合、末尾に / を付加

--- a/zsh/config/lazy.zsh
+++ b/zsh/config/lazy.zsh
@@ -1,0 +1,49 @@
+###################### 遅延読み込み ######################
+# 起動時間を短縮するため、重い補完は初回使用時に読み込む
+
+# kubectl - 初回使用時に補完を読み込む
+if command -v kubectl &>/dev/null; then
+    kubectl() {
+        unfunction kubectl
+        source <(command kubectl completion zsh)
+        command kubectl "$@"
+    }
+fi
+
+# aws - 初回使用時に補完を読み込む
+if command -v aws &>/dev/null; then
+    aws() {
+        unfunction aws
+        if [[ -x /usr/local/bin/aws_completer ]]; then
+            complete -C '/usr/local/bin/aws_completer' aws
+        fi
+        command aws "$@"
+    }
+fi
+
+# go - 初回使用時に補完を読み込む
+if command -v go &>/dev/null && [[ -x "$HOME/go/bin/gocomplete" ]]; then
+    go() {
+        unfunction go
+        complete -C "$HOME/go/bin/gocomplete" go
+        command go "$@"
+    }
+fi
+
+# helm - 初回使用時に補完を読み込む
+if command -v helm &>/dev/null; then
+    helm() {
+        unfunction helm
+        source <(command helm completion zsh)
+        command helm "$@"
+    }
+fi
+
+# terraform - 初回使用時に補完を読み込む
+if command -v terraform &>/dev/null; then
+    terraform() {
+        unfunction terraform
+        complete -o nospace -C terraform terraform
+        command terraform "$@"
+    }
+fi


### PR DESCRIPTION
- 重い補完(kubectl,aws,go,helm,terraform)を遅延読み込みに変更
- aliases.zsh整理: eza,btop,git,docker,k8sエイリアス追加
- zoxide(スマートcd)対応追加
- goコマンド存在時のみGOPATH設定するよう修正
- feh/picomの起動をi3側に統一
- READMEに必要ツールとエイリアス一覧を追加
- i3壁紙の拡張子修正(.png→.jpeg)